### PR TITLE
fix: refactored GET request bodies

### DIFF
--- a/app/notice/notice.controller.js
+++ b/app/notice/notice.controller.js
@@ -14,19 +14,15 @@ router.patch('/close/:id', close);
 module.exports = router;
 
 function get(req, res, next) {
-    let filter = req.body;
-    if (!req.body) {
-        filter = {};
-    }
-    noticeService.get(filter, _.has(req.query, "stale"), _.has(req.query, "closed"))
+    noticeService.get({}, _.has(req.query, "stale"), _.has(req.query, "closed"))
         .then(notices => res.send(notices))
         .catch(err => next(err));
 }
 
 function search(req, res, next) {
-    const text = _.get(req, "body.text");
+    const text = _.get(req, "query.q");
     if (typeof text !== "string" || text.length === 0)
-        return res.status(400).send({message: "Text is required to perform a search. It is expected in a 'text' field of a request body."})
+        return res.status(400).send({message: "Search query is required to perform a search. It is expected in the query parameter 'q'."})
 
     noticeService.search(text)
         .then(notices => res.send(notices))

--- a/app/report/report.controller.js
+++ b/app/report/report.controller.js
@@ -16,10 +16,10 @@ function overview(req, res, next) {
 }
 
 function periodic(req, res, next) {
-	if (!_.has(req.body, "from") || !_.has(req.body, "to"))
-		return res.status(400).send({ message: "Start and end dates are expected. Provide 'from' and 'to' fields" });
-	let from = moment(req.body.from, moment.ISO_8601);
-	let to = moment(req.body.to, moment.ISO_8601);
+	if (!_.has(req.query, "from") || !_.has(req.query, "to"))
+		return res.status(400).send({ message: "Start and end dates are expected. Provide 'from' and 'to' query parameters" });
+	let from = moment(req.query.from, moment.ISO_8601);
+	let to = moment(req.query.to, moment.ISO_8601);
 	if (!from.isValid() || !to.isValid())
 		return res.status(400).send({message: "Provided dates are not valid. Expected format is ISO 8601"});
     reportService.periodic(from.toDate(), to.toDate())

--- a/app/user/user.controller.js
+++ b/app/user/user.controller.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 
 router.post('/authenticate', authenticate);
 router.get('/', findUsers);
+router.get('/search', searchUsers);
 router.post('/register', createUser);
 router.post('/login', login);
 router.get('/:id', findUser);
@@ -27,13 +28,19 @@ function findUser(req, res) {
 }
 
 function findUsers(req, res) {
-    let filter = req.body;
-    if (!req.body) {
-        filter = {};
-    }
-    userService.findUsers(filter)
+    userService.findUsers({})
         .then(data => res.send(data))
         .catch(err => res.status(500).send({ message: `Error fetching the users` }));
+}
+
+function searchUsers(req, res, next) {
+    const text = _.get(req, "query.q");
+    if (typeof text !== "string" || text.length === 0)
+        return res.status(400).send({message: "Search query is required to perform a search. It is expected in the query parameter 'q'."})
+
+    userService.searchUsers(text)
+        .then(users => res.send(users))
+        .catch(err => next(err));
 }
 
 function createUser(req, res) {

--- a/app/user/user.js
+++ b/app/user/user.js
@@ -9,5 +9,10 @@ const User = new Schema ({
     firstName: { type: String },
     lastName: { type: String }
 });
+User.index({
+    lastName: "text",
+    firstName: "text",
+    email: "text"
+});
 
 module.exports = mongoose.model('User', User);

--- a/app/user/user.service.js
+++ b/app/user/user.service.js
@@ -26,6 +26,15 @@ exports.findUsers = (filter) => {
     return User.find(filter, {password: false});
 }
 
+exports.searchUsers = (text) => {
+    return User.find(
+            { $text: { $search: text}}, 
+            { score: { $meta: "textScore" }}
+        ).sort(
+            { closed: 1, score: { $meta: "textScore" }, updatedAt: -1}
+        );
+}
+
 exports.createUser = async (data) => {
     if (!_.has(data, "login") || 
         !_.has(data, "password"))


### PR DESCRIPTION
Some of the GET requests across the app used body as means of passing parameters and data to them. This way the content of request body affected GET methods response.
This behaviour does not follow common worldwide practices nor does it comply with semantics of a GET request: https://stackoverflow.com/a/983458
In addition to that, in some cases one migth not even be able to add a body to a GET request.

All of the GET methods were refactored so that the request body does not matter to the response. Some parameters must now be passed in query.
Affected methods:
- /report/periodic - 'to' and 'from' dates must now be passed in query
- /notice - a custom arbitrary filter may no longer be passed in the request body (one should use /filter/* methods instead)
- /notice/search - search query is now expected in 'q' query parameter (kinda analogous to the way it's done in google: https://www.google.com/search?q=sample+text)
- /user - arbitrary filter may no longer be passed in body; one may now use /user/search though (works the same way as /notice/search)